### PR TITLE
re: #318 Include all fields in getOptionChain

### DIFF
--- a/R/getOptionChain.R
+++ b/R/getOptionChain.R
@@ -21,9 +21,14 @@ getOptionChain.yahoo <- function(Symbols, Exp, ...)
     # clean up colnames, in case there's weirdness in the JSON
     names(x) <- tolower(gsub("[[:space:]]", "", names(x)))
     # set cleaned up colnames to current output colnames
-    d <- with(x, data.frame(Strike=strike, 
+    d <- with(x, data.frame(ContractID= if("contractsymbol" %in% names(x)) {contractsymbol} else {NA},
+                            ConractSize= if("contractsize" %in% names(x)) {contractsize} else {NA},
+                            Currency= if("currency" %in% names(x)) {currency} else {NA},
+                            Expiration= as.POSIXct(expiration,origin="1970-01-01", tz="UTC"),
+                            Strike=strike, 
                             Last=lastprice, 
                             Chg=change,
+                            ChgPct= if("percentchange" %in% names(x)) {percentchange} else {NA},
                             Bid= if("bid" %in% names(x)) {bid} else {NA}, 
                             Ask= if("ask" %in% names(x)) {ask} else {NA},    
                             Vol= if("volume" %in% names(x)) {volume} else {NA}, 


### PR DESCRIPTION
Added fields for the following, which should complete the set:
contractSymbol
currency
percentChange
contractSize
expiration

Converts expiration date to POSIXct to assist estimating theta decay.

Please review the [contributing guide](CONTRIBUTING.md) before submitting your pull request. Please pay special attention to the [pull request](CONTRIBUTING.md#want-to-submit-a-pull-request) and [commit message](CONTRIBUTING.md#commit-messages) sections. Thanks for your contribution and interest in the project!
